### PR TITLE
Added fallbacks for potential null ref errors

### DIFF
--- a/PackageBuilder/Build.cs
+++ b/PackageBuilder/Build.cs
@@ -82,11 +82,12 @@ class Build : NukeBuild
             
             // Assumes we're publishing both zip and unitypackage
             var latestManifest = await GetManifestFromRelease(latestRelease);
-            if (latestRelease == null)
+            if (latestManifest == null)
             {
                 throw new Exception($"Could not get Manifest for release {latestRelease.Name}");
             }
 
+            Serilog.Log.Warning($"Latest manifest? {latestManifest != null}, name: {latestManifest.name}, author: {latestManifest.author}");
             var repoList = new VRCRepoList(packages)
             {
                 author = latestManifest.author?.name ?? GitHubActions.RepositoryOwner,

--- a/PackageBuilder/Build.cs
+++ b/PackageBuilder/Build.cs
@@ -89,7 +89,7 @@ class Build : NukeBuild
 
             var repoList = new VRCRepoList(packages)
             {
-                author = latestManifest.author.name,
+                author = latestManifest.author?.name ?? GitHubActions.RepositoryOwner,
                 name = $"{latestManifest.name} Releases",
                 url = $"https://{GitHubActions.RepositoryOwner}.github.io/{repoName}/index.json"
             };

--- a/PackageBuilder/Build.cs
+++ b/PackageBuilder/Build.cs
@@ -90,7 +90,7 @@ class Build : NukeBuild
             Serilog.Log.Warning($"Latest manifest? {latestManifest != null}, name: {latestManifest.name}, author: {latestManifest.author}");
             var repoList = new VRCRepoList(packages)
             {
-                author = latestManifest.author?.name ?? GitHubActions.RepositoryOwner,
+                author = latestManifest?.author?.name ?? GitHubActions.RepositoryOwner,
                 name = $"{latestManifest.name} Releases",
                 url = $"https://{GitHubActions.RepositoryOwner}.github.io/{repoName}/index.json"
             };

--- a/PackageBuilder/Build.cs
+++ b/PackageBuilder/Build.cs
@@ -87,10 +87,9 @@ class Build : NukeBuild
                 throw new Exception($"Could not get Manifest for release {latestRelease.Name}");
             }
 
-            Serilog.Log.Warning($"Latest manifest? {latestManifest != null}, name: {latestManifest.name}, author: {latestManifest.author}");
             var repoList = new VRCRepoList(packages)
             {
-                author = latestManifest?.author?.name ?? GitHubActions.RepositoryOwner,
+                author = latestManifest.author?.name ?? GitHubActions.RepositoryOwner,
                 name = $"{latestManifest.name} Releases",
                 url = $"https://{GitHubActions.RepositoryOwner}.github.io/{repoName}/index.json"
             };
@@ -149,6 +148,14 @@ class Build : NukeBuild
             }
             var indexPath = ListPublishDirectory / "index.html";
             string indexTemplateContent = File.ReadAllText(indexPath);
+            
+            if (manifest.author == null) {
+                manifest.author = new VRC.PackageManagement.Core.Types.Packages.Author{
+                    name = GitHubActions.RepositoryOwner,
+                    url = $"https://github.com/{GitHubActions.RepositoryOwner}"
+                };
+            }
+
             var rendered = Scriban.Template.Parse(indexTemplateContent).Render(new {manifest, assets=new{zip=zipUrl, unityPackage=unityPackageUrl}}, member => member.Name);
             File.WriteAllText(indexPath, rendered);
             Serilog.Log.Information($"Updated index page at {indexPath}");


### PR DESCRIPTION
If the user didn't have an `author` field with `name` in their `package.json` - the build process would crash with a very opaque error.

This PR makes it so the builder will fall back to the repository owner name if it wasn't defined in the package.