### PR TITLE
Don't choke on non-conforming releases

### DIFF
--- a/PackageBuilder/Build.cs
+++ b/PackageBuilder/Build.cs
@@ -135,11 +135,18 @@ class Build : NukeBuild
             foreach (var release in releases)
             {
                 // Release must have package.json and .zip file, or else it will throw an exception here
-                var manifest = await GetManifestFromRelease(release);
-                if (manifest == null)
+                try
                 {
-                    Serilog.Log.Error($"Could not get manifest from {release.Name}");
-                    return;
+                    var manifest = await GetManifestFromRelease(release);
+                    if (manifest == null)
+                    {
+                        Serilog.Log.Error($"Could not get manifest from {release.Name}");
+                        continue;
+                    }
+                }
+                catch (Exception e)
+                {
+                    continue;
                 }
                 
                 ReleaseAsset zipAsset = release.Assets.First(asset => asset.Name.EndsWith(".zip"));

--- a/PackageBuilder/Build.cs
+++ b/PackageBuilder/Build.cs
@@ -143,17 +143,17 @@ class Build : NukeBuild
                         Serilog.Log.Error($"Could not get manifest from {release.Name}");
                         continue;
                     }
+
+                    ReleaseAsset zipAsset = release.Assets.First(asset => asset.Name.EndsWith(".zip"));
+
+                    // Set url to .zip asset, add latest package version
+                    manifest.url = zipAsset.BrowserDownloadUrl;
+                    packages.Add(manifest);
                 }
                 catch (Exception e)
                 {
                     continue;
                 }
-                
-                ReleaseAsset zipAsset = release.Assets.First(asset => asset.Name.EndsWith(".zip"));
-
-                // Set url to .zip asset, add latest package version
-                manifest.url = zipAsset.BrowserDownloadUrl;
-                packages.Add(manifest);
             }
 
             var latestRelease = await GetLatestRelease(repoName);


### PR DESCRIPTION
I stumbled upon an issue with CI for the AudioLink repo. We have a bunch of older releases from the pre-VCC days. This nuke script hard chokes on these releases, since they don't conform to the expected structure. In this change, I just ignore the non-conforming releases instead of crashing the CI.

**I don't expect that you'll want to merge this, since the fix is a "hack". I don't know what the workflow for properly debugging this stuff is, so that's what I went with. Now that you know the issue, I suspect you can address in a more proper way. This change worked for me though, so I'm using it for the time being. Feel free to close the PR.**