### PR TITLE
Adds UnityPackage creation as a Target

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -6,6 +6,17 @@
     "build": {
       "type": "object",
       "properties": {
+        "assetPattern": {
+          "type": "array",
+          "description": "Adds an asset to the pack. Supports glob matching",
+          "items": {
+            "type": "string"
+          }
+        },
+        "assetRoot": {
+          "type": "string",
+          "description": "Sets the root directory for the assets. Used in dependency analysis to only check files that could be potentially included"
+        },
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
@@ -17,6 +28,13 @@
         "CurrentPackageName": {
           "type": "string",
           "description": "PackageName"
+        },
+        "excludePattern": {
+          "type": "array",
+          "description": "Adds an asset to the pack. Supports glob matching",
+          "items": {
+            "type": "string"
+          }
         },
         "Help": {
           "type": "boolean",
@@ -46,6 +64,10 @@
         "ListPublishDirectory": {
           "type": "string",
           "description": "Directory to save index into"
+        },
+        "LocalTestPackagesPath": {
+          "type": "string",
+          "description": "Path to Target Package"
         },
         "NoLogo": {
           "type": "boolean",
@@ -85,9 +107,14 @@
             "type": "string",
             "enum": [
               "BuildMultiPackageListing",
-              "BuildRepoListing"
+              "BuildRepoListing",
+              "BuildUnityPackage"
             ]
           }
+        },
+        "skipDep": {
+          "type": "boolean",
+          "description": "Skips dependency analysis. Disabling this feature may result in missing assets in your packages"
         },
         "Target": {
           "type": "array",
@@ -96,9 +123,18 @@
             "type": "string",
             "enum": [
               "BuildMultiPackageListing",
-              "BuildRepoListing"
+              "BuildRepoListing",
+              "BuildUnityPackage"
             ]
           }
+        },
+        "unityPackageExportOutput": {
+          "type": "string",
+          "description": "Output .unitypackage file"
+        },
+        "unityPackageExportSource": {
+          "type": "string",
+          "description": "Unity Project Directory"
         },
         "Verbosity": {
           "type": "string",

--- a/PackageBuilder/PackageBuilder.csproj
+++ b/PackageBuilder/PackageBuilder.csproj
@@ -11,6 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
     <PackageReference Include="Nuke.Common" Version="6.2.1" />
     <PackageReference Include="Scriban" Version="5.5.0" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />

--- a/PackageBuilder/UnityPackage/Dependency/AssetAnalyser.cs
+++ b/PackageBuilder/UnityPackage/Dependency/AssetAnalyser.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityPackageExporter.Dependency;
+
+namespace UnityPackageExporter.Dependency
+{
+    /// <summary>Analyses Assets for their dependencies</summary>
+    class AssetAnalyser
+    {
+        static readonly Serilog.ILogger Logger = Serilog.Log.ForContext<AssetAnalyser>();
+
+        private Dictionary<AssetID, FileInfo> fileIndex = new Dictionary<AssetID, FileInfo>();
+        private Dictionary<string, AssetID> guidIndex = new Dictionary<string, AssetID>();
+
+        public string ProjectPath { get; }
+
+        public AssetAnalyser(string projectPath)
+        {
+            ProjectPath = projectPath;
+        }
+
+        /// <summary>Adds a file to the list of valid assets to check</summary>
+        public async Task AddFileAsync(string file)
+        {
+            Logger.Debug("Adding file {0}", file);
+
+            string filePath = Path.GetExtension(file) == ".meta" ? file : $"{file}.meta";
+            var assetID = await AssetParser.ReadAssetIDAsync(filePath);
+            fileIndex[assetID] = new FileInfo(filePath.Substring(0, filePath.Length - 5));
+            if (assetID.HasGUID) guidIndex[assetID.guid] = assetID;
+        }
+
+        /// <summary>Adds a list of files to the valid assets to check</summary>
+        public async Task AddFilesAsync(IEnumerable<string> files)
+        {
+            //Task.WhenAll(files.Select(file => AddFileAsync(file)));
+            foreach (var file in files)
+                await AddFileAsync(file);
+        }
+
+        /// <summary>
+        /// Gets a list of all dependencies for the given list of files
+        /// </summary>
+        /// <param name="files"></param>
+        /// <returns></returns>
+        public async Task<IReadOnlyCollection<string>> FindAllDependenciesAsync(IEnumerable<string> files)
+        {
+            Logger.Information("Finding Dependencies");
+
+            HashSet<string> results = new HashSet<string>();
+            Queue<string> queue = new Queue<string>();
+            foreach (var item in files)
+            {
+                if (results.Add(item))
+                    queue.Enqueue(item);
+            }
+
+            // While we have a queue, push the file if we can
+            while (queue.TryDequeue(out var currentFile))
+            {
+                Logger.Debug("Searching {0}", currentFile);
+                var dependencies = await FindFileDependenciesAsync(currentFile);
+                foreach (var dependency in dependencies)
+                {
+                    Logger.Debug(" - Found {0}", dependency);
+                    if (results.Add(dependency))
+                        queue.Enqueue(dependency);
+                }
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Get's a list of files this asset needs. 
+        /// <para>This is a shallow search</para>
+        /// </summary>
+        public async Task<IReadOnlyCollection<string>> FindFileDependenciesAsync(string assetPath)
+        {
+            AssetID[] references = await AssetParser.ReadReferencesAsync(assetPath);
+            HashSet<string> files = new HashSet<string>(references.Length);
+            foreach(AssetID reference in references)
+            {
+                if (TryGetFileFromGUID(reference.guid, out var info))
+                    files.Add(info.FullName);
+            }
+
+            return files;
+        }
+
+        private bool TryGetFileFromGUID(string guid, out FileInfo info) {
+            if (guid != null && guidIndex.TryGetValue(guid, out var assetID))
+            {
+                if (fileIndex.TryGetValue(assetID, out var fi))
+                {
+                    info = fi;
+                    return true;
+                }
+            }
+            
+            info = null;
+            return false;
+        }
+    }
+}

--- a/PackageBuilder/UnityPackage/Dependency/AssetID.cs
+++ b/PackageBuilder/UnityPackage/Dependency/AssetID.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace UnityPackageExporter.Dependency
+{
+    struct AssetID
+    {
+        public string fileID;
+        public string guid;
+
+        public bool HasFileID => fileID != null;
+        public bool HasGUID => guid != null;
+    }
+}

--- a/PackageBuilder/UnityPackage/Dependency/AssetParser.cs
+++ b/PackageBuilder/UnityPackage/Dependency/AssetParser.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace UnityPackageExporter.Dependency
+{
+    /// <summary>Parses unity .meta files</summary>
+    class AssetParser
+    {
+        static readonly Regex Pattern = new Regex(@"(([fF]ileID|guid): ([\-a-z0-9]+))", RegexOptions.Compiled);
+
+        /// <summary>Pending Results</summary>
+        private class PendingReference
+        {
+            public AssetID ID;
+            public int startPosition;
+            public int endPosition =>
+                ID.HasFileID ? 8 + startPosition + ID.fileID.Length : 6 + startPosition + ID.guid.Length;
+        }
+
+        /// <summary>Reads an asset's ID</summary>
+        public static async Task<AssetID> ReadAssetIDAsync(string assetFilePath)
+        {
+            // Get the meta filepath
+            string filePath = Path.GetExtension(assetFilePath) == ".meta" ? assetFilePath : $"{assetFilePath}.meta";
+
+            // Read the file path
+            string content = await File.ReadAllTextAsync(filePath);
+
+            AssetID ID = new AssetID();
+            foreach (Match match in Pattern.Matches(content))
+            {
+                if (match.Groups[2].Value == "guid")
+                    ID.guid = match.Groups[3].Value;
+                else
+                    ID.fileID = match.Groups[3].Value;
+            }
+
+
+            return ID;
+        }
+
+        /// <summary>Pulls a list of FileID and GUIDs used by this file</summary>
+        public static async Task<AssetID[]> ReadReferencesAsync(string assetFilePath)
+        {
+            // Validate it is a correct reference
+            string ext = Path.GetExtension(assetFilePath);
+            switch(ext)
+            {
+                default:
+                    return new AssetID[0];
+                
+                // Valid assets we can parse for references
+                case ".mat":
+                case ".prefab":
+                case ".unity":
+                case ".asset":
+                    break;
+            }
+
+            List<PendingReference> references = new List<PendingReference>();
+            
+            string content = await File.ReadAllTextAsync(assetFilePath);
+            foreach(Match match in Pattern.Matches(content))
+            {
+                // Create a ref
+                bool addReference = true;
+                PendingReference reference = new PendingReference()
+                {
+                    startPosition = match.Index
+                }; 
+
+                // If we are close enough to the previous one, use it instead
+                if (references.Count > 1) {
+                    int maxPosition = references[references.Count - 1].endPosition;
+                    int diff = match.Index - maxPosition;
+                    if (diff <= 3)
+                    {
+                        reference = references[references.Count - 1];
+                        addReference = false;
+                    }
+                }
+
+                // Update the fields
+                if (match.Groups[2].Value == "fileID")
+                    reference.ID.fileID = match.Groups[3].Value;
+                else
+                    reference.ID.guid = match.Groups[3].Value;
+
+                // Add the reference if it needs it
+                if (addReference)
+                    references.Add(reference);
+            }
+
+            return references.Select(pr => pr.ID).ToArray();
+        }
+    }
+}

--- a/PackageBuilder/UnityPackage/Dependency/DependencyAnalyser.cs
+++ b/PackageBuilder/UnityPackage/Dependency/DependencyAnalyser.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.Extensions.FileSystemGlobbing;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace UnityPackageExporter.Dependency
+{
+    class DependencyAnalyser : IDisposable
+    {
+        public string RootPath { get; }
+
+        private ScriptAnalyser scriptAnalyser;
+        private AssetAnalyser assetAnalyser;
+
+        private DependencyAnalyser(string rootPath)
+        {
+            RootPath = rootPath;
+            scriptAnalyser = new ScriptAnalyser(rootPath);
+            assetAnalyser = new AssetAnalyser(rootPath);
+        }
+
+        /// <summary>
+        /// Creates a new Dependency Analyser
+        /// </summary>
+        /// <param name="rootPath">Root path to look for assets in</param>
+        /// <param name="excludePatterns">Patterns to exclude from all results</param>
+        /// <returns></returns>
+        public static Task<DependencyAnalyser> CreateAsync(string rootPath, IEnumerable<string> excludePatterns)
+            => CreateAsync(rootPath, new string[] { "**/*.meta" }, new string[] { "**/*.cs" }, excludePatterns);
+
+        /// <summary>
+        /// Creates a new Dependency Analyser
+        /// </summary>
+        /// <param name="rootPath">Root path to look for assets in</param>
+        /// <param name="assetPatterns">Pattern to find assets. Recommended to scan only .meta files</param>
+        /// <param name="scriptPatterns">Pattern to find scripts. Recommended to scan only .cs files</param>
+        /// <param name="excludePatterns">Patterns to exclude from all results</param>
+        /// <returns></returns>
+        public static async Task<DependencyAnalyser> CreateAsync(string rootPath, IEnumerable<string> assetPatterns, IEnumerable<string> scriptPatterns, IEnumerable<string> excludePatterns)
+        {
+            DependencyAnalyser analyser = new DependencyAnalyser(rootPath);
+
+            // Build file maps. We dont build code map unless we need it (we might not).
+            Matcher assetMatcher = new Matcher();
+            assetMatcher.AddIncludePatterns(assetPatterns);
+            assetMatcher.AddExcludePatterns(excludePatterns);
+            var assetFiles = assetMatcher.GetResultsInFullPath(analyser.RootPath);
+            await analyser.assetAnalyser.AddFilesAsync(assetFiles);
+
+            // The asset dependency doesnt need this as it finds its own meta files
+            Matcher scriptsMatcher = new Matcher();
+            scriptsMatcher.AddIncludePatterns(scriptPatterns);
+            scriptsMatcher.AddExcludePatterns(excludePatterns);
+            var scriptFiles = scriptsMatcher.GetResultsInFullPath(analyser.RootPath);
+            await analyser.scriptAnalyser.AddFilesAsync(scriptFiles);
+
+            return analyser;
+        }
+
+        /// <summary>
+        /// Finds all the dependencies 
+        /// </summary>
+        /// <param name="files"></param>
+        /// <returns></returns>
+        public async Task<IReadOnlyCollection<string>> FindDependenciesAsync(IEnumerable<string> files)
+        {
+            // Find a list of all assets that we need
+            var assets = (await assetAnalyser.FindAllDependenciesAsync(files)).ToArray();
+
+            // Find all the script assets from this list
+            var scripts = await scriptAnalyser.FindAllDependenciesAsync(assets.Where(assetFile => Path.GetExtension(assetFile) == ".cs"));
+
+            // Merge the lists
+            HashSet<string> results = new HashSet<string>();
+            foreach (var asset in assets) results.Add(asset);
+            foreach (var script in scripts) results.Add(script);
+            return results;
+        }
+
+        public void Dispose()
+        {
+            scriptAnalyser?.Dispose();
+            scriptAnalyser = null;      // Setting to null isn't nessary but doing it to feel better.
+            assetAnalyser = null;       // Setting to null isn't nessary but doing it to feel better.
+        }
+    }
+}

--- a/PackageBuilder/UnityPackage/Dependency/DependencyAnalyser.cs
+++ b/PackageBuilder/UnityPackage/Dependency/DependencyAnalyser.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Serilog;
 
 namespace UnityPackageExporter.Dependency
 {
@@ -41,6 +42,8 @@ namespace UnityPackageExporter.Dependency
         public static async Task<DependencyAnalyser> CreateAsync(string rootPath, IEnumerable<string> assetPatterns, IEnumerable<string> scriptPatterns, IEnumerable<string> excludePatterns)
         {
             DependencyAnalyser analyser = new DependencyAnalyser(rootPath);
+            
+            Log.Information($"DependencyAnalyser is Checking for assets in {rootPath}");
 
             // Build file maps. We dont build code map unless we need it (we might not).
             Matcher assetMatcher = new Matcher();

--- a/PackageBuilder/UnityPackage/Dependency/DependencyAnalyser.cs
+++ b/PackageBuilder/UnityPackage/Dependency/DependencyAnalyser.cs
@@ -43,8 +43,6 @@ namespace UnityPackageExporter.Dependency
         {
             DependencyAnalyser analyser = new DependencyAnalyser(rootPath);
             
-            Log.Information($"DependencyAnalyser is Checking for assets in {rootPath}");
-
             // Build file maps. We dont build code map unless we need it (we might not).
             Matcher assetMatcher = new Matcher();
             assetMatcher.AddIncludePatterns(assetPatterns);

--- a/PackageBuilder/UnityPackage/Dependency/ScriptAnalyser.cs
+++ b/PackageBuilder/UnityPackage/Dependency/ScriptAnalyser.cs
@@ -1,0 +1,219 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnityPackageExporter.Dependency
+{
+    class ScriptAnalyser : IDisposable
+    {
+        static readonly Serilog.ILogger Logger = Serilog.Log.ForContext<ScriptAnalyser>();
+
+        private AdhocWorkspace workspace;
+        private Solution solution;
+        private Project project;
+        private Dictionary<string, Document> documents = new Dictionary<string, Document>();
+        private Dictionary<string, string[]> dependencyCache = new Dictionary<string, string[]>();
+
+        public string ProjectPath { get; }
+
+        public ScriptAnalyser(string projectPath)
+        {
+            var mscorlib = PortableExecutableReference.CreateFromFile(typeof(object).Assembly.Location);
+            
+            ProjectPath = projectPath;
+            workspace = new AdhocWorkspace();
+            documents = new Dictionary<string, Document>();
+
+            //Prepare solution
+            var solId = SolutionId.CreateNewId();
+            var solutionInfo = SolutionInfo.Create(solId, VersionStamp.Default);
+            solution = workspace.AddSolution(solutionInfo);
+
+            //Prepare the project
+            project = workspace.AddProject("Sample", LanguageNames.CSharp);
+            project = project.AddMetadataReference(mscorlib)
+                                .WithParseOptions(((CSharpParseOptions)project.ParseOptions)
+                                .WithPreprocessorSymbols("UNITY_EDITOR"));
+        }
+
+        /// <summary>Adds a source code directly as a reference</summary>
+        public void AddSource(string name, string source)
+        {
+            Logger.Debug("Adding source {0}", name);
+
+            dependencyCache.Clear();
+            var src = SourceText.From(source);
+            var doc = project.AddDocument(name, src);
+            project = doc.Project;
+            documents.Add(name, doc);
+        }
+
+        /// <summary>Adds a file to valid source documents</summary>
+        public async Task<bool> AddFileAsync(string file)
+        {
+            Logger.Debug("Adding file {0}", file);
+            if (!File.Exists(file))
+            {
+                Logger.Error("File {0} does not exist", file);
+                return false;
+            }
+
+            var name = Path.GetFileName(file);
+            var fileContent = await File.ReadAllTextAsync(file);
+            if (string.IsNullOrWhiteSpace(fileContent))
+            {
+                Logger.Error("File {0} source is empty", file);
+                return false;
+            }
+
+            var src = SourceText.From(fileContent);
+            if (src == null)
+            {
+                Logger.Error("File {0} source is invalid", file);
+                return false;
+            }
+
+            dependencyCache.Clear();
+            var doc = project.AddDocument(name, src, filePath: file);
+            if (src == null)
+            {
+                Logger.Error("File {0} document is invalid", file);
+                return false;
+            }
+
+            project = doc.Project;
+            documents.Add(file, doc);
+            return true;
+        }
+
+        /// <summary>Adds a list of documents to valid source documents</summary>
+        public async Task AddFilesAsync(IEnumerable<string> files)
+        {
+            //Task.WhenAll(files.Select(file => AddFileAsync(file)));
+            foreach (var file in files)
+                await AddFileAsync(file);
+        }
+        
+
+        /// <summary>Perofrms a deep search and finds all the dependencies for this file</summary>
+        public async Task<IReadOnlyCollection<string>> FindAllDependenciesAsync(IEnumerable<string> files)
+        {
+            Logger.Information("Finding Dependencies");
+
+            HashSet<string> results = new HashSet<string>();
+            Queue<string> queue = new Queue<string>();
+            foreach (var item in files)
+            {
+                if (results.Add(item))
+                    queue.Enqueue(item);
+            }
+
+            // While we have a queue, push the file if we can
+            while (queue.TryDequeue(out var currentFile))
+            {
+                Logger.Debug("Searching {0}", currentFile);
+                var dependencies = await FindFileDependenciesAsync(currentFile);
+                foreach (var dependency in dependencies)
+                {
+                    Logger.Debug(" - Found {0}", dependency);
+                    if (results.Add(dependency))
+                        queue.Enqueue(dependency);
+                }
+            }
+
+            return results;
+        }
+
+        /// <summary>Finds the shallow list of dependencies</summary>
+        public async Task<string[]> FindFileDependenciesAsync(string file)
+        {
+            if (!documents.ContainsKey(file))
+                await AddFileAsync(file);
+
+            if (dependencyCache.Count == 0)
+                await BuidDependencyMap();
+
+            if (dependencyCache.TryGetValue(file, out var deps))
+                return deps;
+
+            return new string[0];
+        }
+
+        /// <summary>Builds the internal dependency map</summary>
+        public async Task BuidDependencyMap()
+        {
+            Logger.Information("Building Dependency Map");
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            ConcurrentDictionary<string, ConcurrentBag<string>> mapping = new ConcurrentDictionary<string, ConcurrentBag<string>>();
+            await ParallelForEachAsync(project.Documents, (document) => FindSourceDependents(document, mapping), 16);
+            dependencyCache = mapping.ToDictionary((kp) => kp.Key, (kp) => kp.Value.Distinct().ToArray());
+            
+            Logger.Debug("Finished building map. Took {0}ms", stopwatch.ElapsedMilliseconds);
+        }
+
+        private async Task FindSourceDependents(Document sourceDocument, ConcurrentDictionary<string, ConcurrentBag<string>> mapping)
+        {
+            string sourceFile = sourceDocument.FilePath ?? sourceDocument.Name;
+            Logger.Debug("Scanning references of {0}", sourceFile);
+
+            var model = await sourceDocument.GetSemanticModelAsync();
+            var root = await sourceDocument.GetSyntaxRootAsync();
+
+            foreach (var syntax in root.DescendantNodes().Where(node => node is TypeDeclarationSyntax || node is EnumDeclarationSyntax))
+            {
+                var symbol = (INamedTypeSymbol)model.GetDeclaredSymbol(syntax);
+                if (symbol == null) return;
+
+                //////// IMPORTANT SOLUTION IS IMMUTABLE IT NEEDS TO BE PROJECT.SOLUTION
+                var references = await SymbolFinder.FindReferencesAsync(symbol, project.Solution);
+                foreach (var reference in references)
+                {
+                    foreach (var location in reference.Locations)
+                    {
+                        string refFile = location.Document.FilePath ?? location.Document.Name;
+                        if (!mapping.ContainsKey(refFile))
+                            mapping.TryAdd(refFile, new ConcurrentBag<string>());
+                        mapping[refFile].Add(sourceFile);
+                    }
+                }
+            }
+        }
+
+        private static Task ParallelForEachAsync<T>(IEnumerable<T> source, Func<T, Task> funcBody, int maxDoP = 4)
+        {
+            async Task AwaitPartition(IEnumerator<T> partition)
+            {
+                using (partition)
+                {
+                    while (partition.MoveNext())
+                    {
+                        await Task.Yield(); // prevents a sync/hot thread hangup
+                        await funcBody(partition.Current);
+                    }
+                }
+            }
+
+            return Task.WhenAll(
+                Partitioner
+                    .Create(source)
+                    .GetPartitions(maxDoP)
+                    .AsParallel()
+                    .Select(p => AwaitPartition(p)));
+        }
+
+        public void Dispose()
+        {
+            workspace.Dispose();
+        }
+    }
+}

--- a/PackageBuilder/UnityPackage/Package/PackageEntry.cs
+++ b/PackageBuilder/UnityPackage/Package/PackageEntry.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+
+namespace UnityPackageExporter.Package
+{
+    /// <summary>
+    /// Unity Package asset
+    /// </summary>
+    class PackageEntry
+    {
+        /// <summary>Relative path of the asset</summary>
+        public string RelativeFilePath { get; set; }
+        /// <summary>Content of the asset</summary>
+        public byte[] Content { get; set; }
+        /// <summary>Content of the metadata</summary>
+        public byte[] Metadata { get; set; }
+
+        /// <summary>Is this file writable</summary>
+        internal bool IsWriteable
+            => !string.IsNullOrEmpty(RelativeFilePath) && Content?.Length > 0 && Metadata?.Length > 0;
+
+        /// <summary>
+        /// Writes the entry to file
+        /// </summary>
+        /// <param name="destination">Root directory the entry will be written relative to.</param>
+        /// <returns></returns>
+        public async Task WriteFileAsync(string destination)
+        {
+            // Prepare the folder
+            string path = Path.Combine(destination, RelativeFilePath);
+            string dir = Path.GetDirectoryName(path);
+            Directory.CreateDirectory(dir);
+
+            // Write the contents
+            await Task.WhenAll(
+                File.WriteAllBytesAsync(path, Content),
+                File.WriteAllBytesAsync(path + ".meta", Content)
+            );
+        }
+    }
+}

--- a/PackageBuilder/UnityPackage/Package/Packer.cs
+++ b/PackageBuilder/UnityPackage/Package/Packer.cs
@@ -1,0 +1,215 @@
+﻿using ICSharpCode.SharpZipLib.GZip;
+using ICSharpCode.SharpZipLib.Tar;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnityPackageExporter.Package
+{
+    /// <summary>Packs file into a Unity Package</summary>
+    class Packer : IDisposable, IAsyncDisposable
+    {
+        static readonly Serilog.ILogger Logger = Serilog.Log.ForContext<Packer>();
+
+        /// <summary>Path to the Unity Project</summary>
+        public string ProjectPath { get; }
+        /// <summary>Output file path. If a stream is given, this is null.</summary>
+        public string OutputPath { get; }
+
+        private Stream _outStream;
+        private GZipOutputStream _gzStream;
+        private TarOutputStream _tarStream;
+
+        private HashSet<string> _files;
+        public IReadOnlyCollection<string> Files => _files;
+
+        /// <summary>
+        /// Creates a new Packer that writes to the output file
+        /// </summary>
+        /// <param name="projectPath">Path to the Unity Project</param>
+        /// <param name="output">The .unitypackage file</param>
+        public Packer(string projectPath, string output) : this(projectPath, new FileStream(output, FileMode.OpenOrCreate)) 
+        {
+            OutputPath = output;
+        }
+
+        /// <summary>
+        /// Creates a new Packer that writes to the outputStream
+        /// </summary>
+        /// <param name="projectPath">Path to the Unity Project</param>
+        /// <param name="stream">The stream the contents will be written to</param>
+        public Packer(string projectPath, Stream stream)
+        {
+            ProjectPath = projectPath;
+            OutputPath = null;
+
+            _files = new HashSet<string>();
+            _outStream = stream;
+            _gzStream = new GZipOutputStream(_outStream);
+            _tarStream = new TarOutputStream(_gzStream, Encoding.UTF8);
+
+        }
+
+        /// <summary>
+        /// Adds an asset to the pack.
+        /// <para>If the asset is already in the pack, then it will be skipped.</para>
+        /// </summary>
+        /// <param name="filePath">The full path to the asset</param>
+        /// <returns>If the asset was written to the pack. </returns>
+        public async Task<bool> AddAssetAsync(string filePath)
+        {
+            FileInfo file = new FileInfo(Path.GetExtension(filePath) == ".meta" ? filePath.Substring(0, filePath.Length - 5) : filePath);
+            if (!file.Exists)
+            {
+                if (Directory.Exists(file.FullName))
+                {
+                    Logger.Warning($"Attempted to add a folder {file.FullName} as a file. This is not supported.");
+                    return false;
+                }
+
+                throw new FileNotFoundException($"Could not find the file {file.FullName}");
+            }
+             
+            if (!_files.Add(file.FullName)) 
+                return false;
+
+            string relativePath = Path.GetRelativePath(ProjectPath, file.FullName);
+            string metaFile = $"{file.FullName}.meta";
+            string guidString = "";
+            string metaContents;
+
+            if (!File.Exists(metaFile))
+            {
+                //Meta file is missing so we have to generate it ourselves.
+                Logger.Warning("Missing .meta for {0}", relativePath);
+
+                Guid guid = Guid.NewGuid();
+                foreach (var byt in guid.ToByteArray())
+                    guidString += string.Format("{0:X2}", byt);
+
+                var builder = new System.Text.StringBuilder();
+                builder.Append("guid: " + new Guid()).Append("\n");
+                metaContents = builder.ToString();
+            }
+            else
+            {
+                //Read the meta contents
+                metaContents = File.ReadAllText(metaFile);
+
+                int guidIndex = metaContents.IndexOf("guid: ");
+                guidString = metaContents.Substring(guidIndex + 6, 32);
+            }
+
+            try
+            {
+                Logger.Information("Writing File {0} ( {1} )", relativePath, guidString);
+                await _tarStream.WriteFileAsync(file.FullName, $"{guidString}/asset");
+                await _tarStream.WriteAllTextAsync($"{guidString}/asset.meta", metaContents);
+                await _tarStream.WriteAllTextAsync($"{guidString}/pathname", relativePath.Replace('\\', '/'));
+            }
+            catch(FileNotFoundException fnf)
+            {
+                Logger.Error($"Failed to write: {fnf.Message}");
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Adds assets to the pack
+        /// <para>If an asset is already in the pack then it will be skipped</para>
+        /// </summary>
+        /// <param name="assets"></param>
+        /// <returns></returns>
+        public async Task AddAssetsAsync(IEnumerable<string> assets)
+        {
+            foreach(var asset in assets)
+                await AddAssetAsync(asset);
+        }
+
+        public Task FlushAsync()
+            => _tarStream.FlushAsync();
+
+        public void Dispose()
+        {
+            _tarStream.Dispose();
+            _gzStream.Dispose();
+            _outStream.Dispose();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _tarStream.DisposeAsync();
+            await _gzStream.DisposeAsync();
+            await _outStream.DisposeAsync();
+        }
+
+        /// <summary>Unpacks all the assets</summary>
+        public static Task<IEnumerable<PackageEntry>> Unpack(string package)
+        {
+            using var fileStream = new FileStream(package, FileMode.Open);
+            return Unpack(fileStream);
+        }
+
+        /// <summary>Unpacks all assets</summary>
+        public async static Task<IEnumerable<PackageEntry>> Unpack(Stream package)
+        {
+            using var gzoStream = new GZipInputStream(package);
+            using var tarStream = new TarInputStream(gzoStream, Encoding.UTF8);
+
+            Dictionary<string, PackageEntry> entries = new Dictionary<string, PackageEntry>();
+
+            TarEntry tarEntry;
+            while ((tarEntry = tarStream.GetNextEntry()) != null)
+            {
+                if (tarEntry.IsDirectory)
+                    continue;
+
+                string[] parts = tarEntry.Name.Split('/');
+                string file = parts[1];
+                string guid = parts[0];
+                byte[] data = null;
+
+                //Create a new memory stream and read the entries into it.
+                using (MemoryStream mem = new MemoryStream())
+                {
+                    await tarStream.ReadNextFileAsync(mem);
+                    data = mem.ToArray();
+                }
+
+                //Make sure we actually read data
+                if (data == null)
+                    continue;
+
+                //Add a new element
+                if (!entries.ContainsKey(guid))
+                    entries.Add(guid, new PackageEntry());
+
+                switch (file)
+                {
+                    case "asset":
+                        entries[guid].Content = data;
+                        break;
+
+                    case "asset.meta":
+                        entries[guid].Metadata = data;
+                        break;
+
+                    case "pathname":
+                        string path = Encoding.ASCII.GetString(data);
+                        entries[guid].RelativeFilePath = path;
+                        break;
+
+                    default:
+                        Logger.Warning("Skipping {0} because its a unkown file", tarEntry.Name);
+                        break;
+                }
+            }
+
+            return entries.Values;
+        }
+    }
+}

--- a/PackageBuilder/UnityPackage/Package/TarStreamExtensions.cs
+++ b/PackageBuilder/UnityPackage/Package/TarStreamExtensions.cs
@@ -1,0 +1,126 @@
+﻿using ICSharpCode.SharpZipLib.Tar;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace UnityPackageExporter.Package
+{
+
+
+    public static class TarStreamExtensions
+    {
+        /// <summary>
+        /// Reads and writes a file to the stream
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="source"></param>
+        /// <param name="dest"></param>
+        public static async Task WriteFileAsync(this TarOutputStream stream, string source, string dest)
+        {
+            using (Stream inputStream = File.OpenRead(source))
+            {
+                long fileSize = inputStream.Length;
+
+                // Create a tar entry named as appropriate. You can set the name to anything,
+                // but avoid names starting with drive or UNC.
+                TarEntry entry = TarEntry.CreateTarEntry(dest);
+
+                // Must set size, otherwise TarOutputStream will fail when output exceeds.
+                entry.Size = fileSize;
+
+                // Add the entry to the tar stream, before writing the data.
+                stream.PutNextEntry(entry);
+
+                // this is copied from TarArchive.WriteEntryCore
+                byte[] localBuffer = new byte[32 * 1024];
+                while (true)
+                {
+                    int numRead = await inputStream.ReadAsync(localBuffer, 0, localBuffer.Length);
+                    if (numRead <= 0)
+                        break;
+
+                    await stream.WriteAsync(localBuffer, 0, numRead);
+                }
+
+                //Close the entry
+                stream.CloseEntry();
+            }
+        }
+
+        /// <summary>
+        /// Writes all text to the stream
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="dest"></param>
+        /// <param name="content"></param>
+        public static async Task WriteAllTextAsync(this TarOutputStream stream, string dest, string content)
+        {
+            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(content);
+
+            TarEntry entry = TarEntry.CreateTarEntry(dest);
+            entry.Size = bytes.Length;
+
+            // Add the entry to the tar stream, before writing the data.
+            stream.PutNextEntry(entry);
+
+            // this is copied from TarArchive.WriteEntryCore
+            await stream.WriteAsync(bytes, 0, bytes.Length);
+
+            //Close the entry
+            stream.CloseEntry();
+        }
+
+        /// <summary>
+        /// Reads the next file in the stream
+        /// </summary>
+        /// <param name="tarIn"></param>
+        /// <param name="outStream"></param>
+        /// <returns></returns>
+        public async static Task<long> ReadNextFileAsync(this TarInputStream tarIn, Stream outStream)
+        {
+            long totalRead = 0;
+            byte[] buffer = new byte[4096];
+            bool isAscii = true;
+            bool cr = false;
+
+            int numRead = await tarIn.ReadAsync(buffer, 0, buffer.Length);
+            int maxCheck = Math.Min(200, numRead);
+
+            totalRead += numRead;
+
+            for (int i = 0; i < maxCheck; i++)
+            {
+                byte b = buffer[i];
+                if (b < 8 || (b > 13 && b < 32) || b == 255)
+                {
+                    isAscii = false;
+                    break;
+                }
+            }
+
+            while (numRead > 0)
+            {
+                if (isAscii)
+                {
+                    // Convert LF without CR to CRLF. Handle CRLF split over buffers.
+                    for (int i = 0; i < numRead; i++)
+                    {
+                        byte b = buffer[i];     // assuming plain Ascii and not UTF-16
+                        if (b == 10 && !cr)     // LF without CR
+                            outStream.WriteByte(13);
+                        cr = (b == 13);
+
+                        outStream.WriteByte(b);
+                    }
+                }
+                else
+                    outStream.Write(buffer, 0, numRead);
+
+                numRead = await tarIn.ReadAsync(buffer, 0, buffer.Length);
+                totalRead += numRead;
+            }
+
+            return totalRead;
+        }
+    }
+}

--- a/PackageBuilder/UnityPackage/UnityPackageExport.cs
+++ b/PackageBuilder/UnityPackage/UnityPackageExport.cs
@@ -73,9 +73,15 @@ partial class Build
             // Match all the assets we need
             Matcher assetMatcher = new Matcher();
             assetMatcher.AddIncludePatterns(assetPattern);
-            Log.Information($"Added includePattern {assetPattern}");
+            foreach (string s in assetPattern)
+            {
+                Log.Information($"Added includePattern {s}");
+            }
             assetMatcher.AddExcludePatterns(excludePattern);
-            Log.Information($"Added excludePattern {excludePattern}");
+            foreach (string s in excludePattern)
+            {
+                Log.Information($"Added excludePattern {s}");
+            }
             assetMatcher.AddExclude(unityPackageExportOutput);
             Log.Information($"Added exclude {unityPackageExportOutput}");
 

--- a/PackageBuilder/UnityPackage/UnityPackageExport.cs
+++ b/PackageBuilder/UnityPackage/UnityPackageExport.cs
@@ -25,7 +25,7 @@ partial class Build
     string[] assetPattern = new string[]{"**.*"};
 
     [Parameter("Adds an asset to the pack. Supports glob matching.", Separator = " ")]
-    string[] excludePattern = new string[] { "Library/**.*", "**/.*" };
+    string[] excludePattern = new string[] { "Library/**.*"};
     
     [Parameter("Skips dependency analysis. Disabling this feature may result in missing assets in your packages.")]
     bool skipDep = false;

--- a/PackageBuilder/UnityPackage/UnityPackageExport.cs
+++ b/PackageBuilder/UnityPackage/UnityPackageExport.cs
@@ -2,7 +2,8 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using Microsoft.Extensions.FileSystemGlobbing;
+using GlobExpressions;
+// using Microsoft.Extensions.FileSystemGlobbing;
 using Nuke.Common;
 using Nuke.Common.IO;
 using Serilog;
@@ -72,23 +73,53 @@ partial class Build
             using DependencyAnalyser analyser = !skipDep ? await DependencyAnalyser.CreateAsync(unityPackageExportSource / assetRoot, excludePattern) : null;
             using Packer packer = new Packer(unityPackageExportSource, unityPackageExportOutput);
 
-            // Match all the assets we need
-            Matcher assetMatcher = new Matcher();
-            assetMatcher.AddIncludePatterns(assetPattern);
-            foreach (string s in assetPattern)
-            {
-                Log.Information($"Added includePattern {s}");
-            }
-            // assetMatcher.AddExcludePatterns(excludePattern);
-            // foreach (string s in excludePattern)
-            // {
-            //     Log.Information($"Added excludePattern {s}");
-            // }
-            assetMatcher.AddExclude(unityPackageExportOutput);
-            Log.Information($"Added exclude {unityPackageExportOutput}");
+            // Use Nuke's globbing to match the assets
+            
+            // Get all files in the directory and its subdirectories
+            var rootPath = unityPackageExportSource;
+            var allFiles = Directory.GetFiles(rootPath, "*.*", SearchOption.AllDirectories);
 
-            var matchedAssets = assetMatcher.GetResultsInFullPath(unityPackageExportSource);
+            List<string> matchedAssets = new List<string>();
+            // Iterate through the files and apply the include and exclude patterns
+            Log.Information("Matched files:");
+            foreach (var filePath in allFiles)
+            {
+                // Get the relative path to the root directory
+                string relativePath = Path.GetRelativePath(rootPath, filePath);
+
+                // Check if the file matches any of the include patterns and does not match any of the exclude patterns
+                bool isIncluded = AnyPatternMatches(relativePath, assetPattern);
+                bool isExcluded = AnyPatternMatches(relativePath, excludePattern);
+
+                if (isIncluded && !isExcluded)
+                {
+                    Log.Information($"Matched file: {relativePath}");
+                    matchedAssets.Add(relativePath);
+                }
+            }
+            
+            // Match all the assets we need
+            // Matcher assetMatcher = new Matcher();
+            // assetMatcher.AddIncludePatterns(assetPattern);
+            // foreach (string s in assetPattern)
+            // {
+            //     Log.Information($"Added includePattern {s}");
+            // }
+            // // assetMatcher.AddExcludePatterns(excludePattern);
+            // // foreach (string s in excludePattern)
+            // // {
+            // //     Log.Information($"Added excludePattern {s}");
+            // // }
+            // assetMatcher.AddExclude(unityPackageExportOutput);
+            // Log.Information($"Added exclude {unityPackageExportOutput}");
+            //
+            // var matchedAssets = assetMatcher.GetResultsInFullPath(unityPackageExportSource);
+            //
+            Assert.True(matchedAssets.Count() > 0, "No assets matched the pattern. Please check your pattern and try again.");
+            
             Log.Information($"Found {matchedAssets.Count()} matched assets");
+            
+            
             await packer.AddAssetsAsync(matchedAssets);
 
             if (!skipDep)
@@ -101,4 +132,17 @@ partial class Build
             Log.Information($"Finished Packing in {timer.ElapsedMilliseconds}ms to {packer.OutputPath}");
             await packer.FlushAsync();
         });
+    
+    // Helper method to check if any pattern in the given array matches the provided path
+    static bool AnyPatternMatches(string path, string[] patterns)
+    {
+        foreach (var pattern in patterns)
+        {
+            if (Glob.IsMatch(path, pattern))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/PackageBuilder/UnityPackage/UnityPackageExport.cs
+++ b/PackageBuilder/UnityPackage/UnityPackageExport.cs
@@ -63,6 +63,8 @@ partial class Build
         {
             Log.Information($"Packing {unityPackageExportSource}");
             
+            PrintDirectoryTree(unityPackageExportSource/"Packages"/"com.vrchat.ClientSim");
+            
             // Make the output file (touch it) so we can exclude
             await File.WriteAllBytesAsync(unityPackageExportOutput, new byte[0]);
 

--- a/PackageBuilder/UnityPackage/UnityPackageExport.cs
+++ b/PackageBuilder/UnityPackage/UnityPackageExport.cs
@@ -79,11 +79,11 @@ partial class Build
             {
                 Log.Information($"Added includePattern {s}");
             }
-            assetMatcher.AddExcludePatterns(excludePattern);
-            foreach (string s in excludePattern)
-            {
-                Log.Information($"Added excludePattern {s}");
-            }
+            // assetMatcher.AddExcludePatterns(excludePattern);
+            // foreach (string s in excludePattern)
+            // {
+            //     Log.Information($"Added excludePattern {s}");
+            // }
             assetMatcher.AddExclude(unityPackageExportOutput);
             Log.Information($"Added exclude {unityPackageExportOutput}");
 

--- a/PackageBuilder/UnityPackage/UnityPackageExport.cs
+++ b/PackageBuilder/UnityPackage/UnityPackageExport.cs
@@ -1,10 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using GlobExpressions;
 using Microsoft.Extensions.FileSystemGlobbing;
-// using Microsoft.Extensions.FileSystemGlobbing;
 using Nuke.Common;
 using Nuke.Common.IO;
 using Serilog;
@@ -34,29 +31,6 @@ partial class Build
     
     [Parameter("Sets the root directory for the assets. Used in dependency analysis to only check files that could be potentially included.")]
     string assetRoot = "Assets";
-    
-    static void PrintDirectoryTree(string directoryPath, string indent = "")
-    {
-        DirectoryInfo directoryInfo = new DirectoryInfo(directoryPath);
-
-        if (!directoryInfo.Exists)
-        {
-            Log.Information($"Directory \"{directoryPath}\" not found.");
-            return;
-        }
-
-        Log.Information($"{indent}+ {directoryInfo.Name}");
-
-        foreach (DirectoryInfo subDirectory in directoryInfo.GetDirectories())
-        {
-            PrintDirectoryTree(subDirectory.FullName, indent + "  ");
-        }
-
-        foreach (FileInfo file in directoryInfo.GetFiles())
-        {
-            Log.Information($"{indent}  - {file.Name}");
-        }
-    }
 
     Target BuildUnityPackage => _ => _
         .Requires(() => unityPackageExportSource)
@@ -75,25 +49,10 @@ partial class Build
             // Match all the assets we need
             Matcher assetMatcher = new Matcher();
             assetMatcher.AddIncludePatterns(assetPattern);
-            foreach (string s in assetPattern)
-            {
-                Log.Information($"Added includePattern {s}");
-            }
             assetMatcher.AddExcludePatterns(excludePattern);
-            foreach (string s in excludePattern)
-            {
-                Log.Information($"Added excludePattern {s}");
-            }
             assetMatcher.AddExclude(unityPackageExportOutput);
-            Log.Information($"Added exclude {unityPackageExportOutput}");
             
             var matchedAssets = assetMatcher.GetResultsInFullPath(unityPackageExportSource);
-            
-            var newMatcher = new Matcher();
-            newMatcher.AddInclude("Packages/com.vrchat.ClientSim/**/*.*");
-            var matched2 = newMatcher.GetResultsInFullPath(unityPackageExportSource);
-            Log.Information($"NewMatcher found {matched2.Count()} files.");
-                
 
             Assert.True(matchedAssets.Count() > 0, "No assets matched the pattern. Please check your pattern and try again.");
             
@@ -112,17 +71,4 @@ partial class Build
             Log.Information($"Finished Packing in {timer.ElapsedMilliseconds}ms to {packer.OutputPath}");
             await packer.FlushAsync();
         });
-    
-    // Helper method to check if any pattern in the given array matches the provided path
-    static bool AnyPatternMatches(string path, string[] patterns)
-    {
-        foreach (var pattern in patterns)
-        {
-            if (Glob.IsMatch(path, pattern))
-            {
-                return true;
-            }
-        }
-        return false;
-    }
 }

--- a/PackageBuilder/UnityPackage/UnityPackageExport.cs
+++ b/PackageBuilder/UnityPackage/UnityPackageExport.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Nuke.Common;
 using Nuke.Common.IO;
@@ -72,10 +73,14 @@ partial class Build
             // Match all the assets we need
             Matcher assetMatcher = new Matcher();
             assetMatcher.AddIncludePatterns(assetPattern);
+            Log.Information($"Added includePattern {assetPattern}");
             assetMatcher.AddExcludePatterns(excludePattern);
+            Log.Information($"Added excludePattern {excludePattern}");
             assetMatcher.AddExclude(unityPackageExportOutput);
+            Log.Information($"Added exclude {unityPackageExportOutput}");
 
             var matchedAssets = assetMatcher.GetResultsInFullPath(unityPackageExportSource);
+            Log.Information($"Found {matchedAssets.Count()} matched assets");
             await packer.AddAssetsAsync(matchedAssets);
 
             if (!skipDep)

--- a/PackageBuilder/UnityPackage/UnityPackageExport.cs
+++ b/PackageBuilder/UnityPackage/UnityPackageExport.cs
@@ -62,8 +62,6 @@ partial class Build
         {
             Log.Information($"Packing {unityPackageExportSource}");
             
-            PrintDirectoryTree(unityPackageExportSource);
-            
             // Make the output file (touch it) so we can exclude
             await File.WriteAllBytesAsync(unityPackageExportOutput, new byte[0]);
 

--- a/PackageBuilder/UnityPackage/UnityPackageExport.cs
+++ b/PackageBuilder/UnityPackage/UnityPackageExport.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.Extensions.FileSystemGlobbing;
+using Nuke.Common;
+using Nuke.Common.IO;
+using Serilog;
+using UnityPackageExporter.Dependency;
+using UnityPackageExporter.Package;
+
+namespace VRC.PackageManagement.Automation;
+
+// Most of this code is adapted from https://github.com/Lachee/Unity-Package-Exporter, which is licensed under the MIT license.
+partial class Build
+{
+
+    [Parameter("Unity Project Directory")]
+    AbsolutePath unityPackageExportSource;
+    
+    [Parameter("Output .unitypackage file")]
+    AbsolutePath unityPackageExportOutput;
+    
+    [Parameter("Adds an asset to the pack. Supports glob matching.", Separator = " ")]
+    string[] assetPattern = new string[]{"**.*"};
+
+    [Parameter("Adds an asset to the pack. Supports glob matching.", Separator = " ")]
+    string[] excludePattern = new string[] { "Library/**.*", "**/.*" };
+    
+    [Parameter("Skips dependency analysis. Disabling this feature may result in missing assets in your packages.")]
+    bool skipDep = false;
+    
+    [Parameter("Sets the root directory for the assets. Used in dependency analysis to only check files that could be potentially included.")]
+    string assetRoot = "Assets";
+
+    Target BuildUnityPackage => _ => _
+        .Requires(() => unityPackageExportSource)
+        .Requires(() => unityPackageExportOutput)
+        .Executes( async () =>
+        {
+            Log.Information($"Packing {unityPackageExportSource}");
+            
+            // Make the output file (touch it) so we can exclude
+            await File.WriteAllBytesAsync(unityPackageExportOutput, new byte[0]);
+
+            Stopwatch timer = Stopwatch.StartNew();
+            using DependencyAnalyser analyser = !skipDep ? await DependencyAnalyser.CreateAsync(Path.Combine(unityPackageExportSource, assetRoot), excludePattern) : null;
+            using Packer packer = new Packer(unityPackageExportSource, unityPackageExportOutput);
+
+            // Match all the assets we need
+            Matcher assetMatcher = new Matcher();
+            assetMatcher.AddIncludePatterns(assetPattern);
+            assetMatcher.AddExcludePatterns(excludePattern);
+            assetMatcher.AddExclude(unityPackageExportOutput);
+
+            var matchedAssets = assetMatcher.GetResultsInFullPath(unityPackageExportSource);
+            await packer.AddAssetsAsync(matchedAssets);
+
+            if (!skipDep)
+            {
+                var results = await analyser.FindDependenciesAsync(matchedAssets);
+                await packer.AddAssetsAsync(results);
+            }
+
+            // Finally flush and tell them we done
+            Log.Information($"Finished Packing in {timer.ElapsedMilliseconds}ms to {packer.OutputPath}");
+            await packer.FlushAsync();
+        });
+}

--- a/PackageBuilder/UnityPackage/UnityPackageExport.cs
+++ b/PackageBuilder/UnityPackage/UnityPackageExport.cs
@@ -31,6 +31,29 @@ partial class Build
     
     [Parameter("Sets the root directory for the assets. Used in dependency analysis to only check files that could be potentially included.")]
     string assetRoot = "Assets";
+    
+    static void PrintDirectoryTree(string directoryPath, string indent = "")
+    {
+        DirectoryInfo directoryInfo = new DirectoryInfo(directoryPath);
+
+        if (!directoryInfo.Exists)
+        {
+            Log.Information($"Directory \"{directoryPath}\" not found.");
+            return;
+        }
+
+        Log.Information($"{indent}+ {directoryInfo.Name}");
+
+        foreach (DirectoryInfo subDirectory in directoryInfo.GetDirectories())
+        {
+            PrintDirectoryTree(subDirectory.FullName, indent + "  ");
+        }
+
+        foreach (FileInfo file in directoryInfo.GetFiles())
+        {
+            Log.Information($"{indent}  - {file.Name}");
+        }
+    }
 
     Target BuildUnityPackage => _ => _
         .Requires(() => unityPackageExportSource)
@@ -38,6 +61,8 @@ partial class Build
         .Executes( async () =>
         {
             Log.Information($"Packing {unityPackageExportSource}");
+            
+            PrintDirectoryTree(unityPackageExportSource);
             
             // Make the output file (touch it) so we can exclude
             await File.WriteAllBytesAsync(unityPackageExportOutput, new byte[0]);

--- a/PackageBuilder/UnityPackage/UnityPackageExport.cs
+++ b/PackageBuilder/UnityPackage/UnityPackageExport.cs
@@ -65,8 +65,6 @@ partial class Build
         {
             Log.Information($"Packing {unityPackageExportSource}");
             
-            PrintDirectoryTree(unityPackageExportSource/"Packages"/"com.vrchat.ClientSim");
-            
             // Make the output file (touch it) so we can exclude
             await File.WriteAllBytesAsync(unityPackageExportOutput, new byte[0]);
 
@@ -92,7 +90,7 @@ partial class Build
             var matchedAssets = assetMatcher.GetResultsInFullPath(unityPackageExportSource);
             
             var newMatcher = new Matcher();
-            newMatcher.AddInclude("**/*.*");
+            newMatcher.AddInclude("Packages/com.vrchat.ClientSim/**/*.*");
             var matched2 = newMatcher.GetResultsInFullPath(unityPackageExportSource);
             Log.Information($"NewMatcher found {matched2.Count()} files.");
                 

--- a/PackageBuilder/UnityPackage/UnityPackageExport.cs
+++ b/PackageBuilder/UnityPackage/UnityPackageExport.cs
@@ -68,7 +68,7 @@ partial class Build
             await File.WriteAllBytesAsync(unityPackageExportOutput, new byte[0]);
 
             Stopwatch timer = Stopwatch.StartNew();
-            using DependencyAnalyser analyser = !skipDep ? await DependencyAnalyser.CreateAsync(Path.Combine(unityPackageExportSource, assetRoot), excludePattern) : null;
+            using DependencyAnalyser analyser = !skipDep ? await DependencyAnalyser.CreateAsync(unityPackageExportSource / assetRoot, excludePattern) : null;
             using Packer packer = new Packer(unityPackageExportSource, unityPackageExportOutput);
 
             // Match all the assets we need

--- a/PackageBuilder/UnityPackage/UnityPackageExport.cs
+++ b/PackageBuilder/UnityPackage/UnityPackageExport.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using GlobExpressions;
+using Microsoft.Extensions.FileSystemGlobbing;
 // using Microsoft.Extensions.FileSystemGlobbing;
 using Nuke.Common;
 using Nuke.Common.IO;
@@ -73,48 +74,29 @@ partial class Build
             using DependencyAnalyser analyser = !skipDep ? await DependencyAnalyser.CreateAsync(unityPackageExportSource / assetRoot, excludePattern) : null;
             using Packer packer = new Packer(unityPackageExportSource, unityPackageExportOutput);
 
-            // Use Nuke's globbing to match the assets
-            
-            // Get all files in the directory and its subdirectories
-            var rootPath = unityPackageExportSource;
-            var allFiles = Directory.GetFiles(rootPath, "*.*", SearchOption.AllDirectories);
-
-            List<string> matchedAssets = new List<string>();
-            // Iterate through the files and apply the include and exclude patterns
-            Log.Information("Matched files:");
-            foreach (var filePath in allFiles)
-            {
-                // Get the relative path to the root directory
-                string relativePath = Path.GetRelativePath(rootPath, filePath);
-
-                // Check if the file matches any of the include patterns and does not match any of the exclude patterns
-                bool isIncluded = AnyPatternMatches(relativePath, assetPattern);
-                bool isExcluded = AnyPatternMatches(relativePath, excludePattern);
-
-                if (isIncluded && !isExcluded)
-                {
-                    Log.Information($"Matched file: {relativePath}");
-                    matchedAssets.Add(relativePath);
-                }
-            }
-            
             // Match all the assets we need
-            // Matcher assetMatcher = new Matcher();
-            // assetMatcher.AddIncludePatterns(assetPattern);
-            // foreach (string s in assetPattern)
-            // {
-            //     Log.Information($"Added includePattern {s}");
-            // }
-            // // assetMatcher.AddExcludePatterns(excludePattern);
-            // // foreach (string s in excludePattern)
-            // // {
-            // //     Log.Information($"Added excludePattern {s}");
-            // // }
-            // assetMatcher.AddExclude(unityPackageExportOutput);
-            // Log.Information($"Added exclude {unityPackageExportOutput}");
-            //
-            // var matchedAssets = assetMatcher.GetResultsInFullPath(unityPackageExportSource);
-            //
+            Matcher assetMatcher = new Matcher();
+            assetMatcher.AddIncludePatterns(assetPattern);
+            foreach (string s in assetPattern)
+            {
+                Log.Information($"Added includePattern {s}");
+            }
+            assetMatcher.AddExcludePatterns(excludePattern);
+            foreach (string s in excludePattern)
+            {
+                Log.Information($"Added excludePattern {s}");
+            }
+            assetMatcher.AddExclude(unityPackageExportOutput);
+            Log.Information($"Added exclude {unityPackageExportOutput}");
+            
+            var matchedAssets = assetMatcher.GetResultsInFullPath(unityPackageExportSource);
+            
+            var newMatcher = new Matcher();
+            newMatcher.AddInclude("**/*.*");
+            var matched2 = newMatcher.GetResultsInFullPath(unityPackageExportSource);
+            Log.Information($"NewMatcher found {matched2.Count()} files.");
+                
+
             Assert.True(matchedAssets.Count() > 0, "No assets matched the pattern. Please check your pattern and try again.");
             
             Log.Information($"Found {matchedAssets.Count()} matched assets");


### PR DESCRIPTION
We were previously using [create-unitypackage](https://github.com/pCYSl5EDgo/create-unitypackage) to create UnityPackages without Unity, but that action did not work properly for UdonSharp and some other repos, producing malformed and unusable outputs. This new approach is adapted from [Unity-Package-Exporter](https://github.com/Lachee/Unity-Package-Exporter), ported to use Nuke instead of a custom one-off project.

The only custom file is [UnityPackageExport.cs](https://github.com/vrchat-community/package-list-action/pull/17/files#diff-674b5f2ebdb67732287f8573010ef0dc0999386c315d4cd93be1d1842c3799a5), the rest are basically imported as-is from the other project.

You can see a successful [run of this target with ClientSim here](https://github.com/vrchat-community/ClientSim/actions/runs/4703925816).

We could probably further streamline the functionality by focusing on exporting packages, which are always within "./Packages/" directories, whereas this code still has some assumptions about the Assets directory. But it's working much better!