### PR TITLE
Make package listing suffix configurable and the URL configurable

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -18,6 +18,10 @@
           "type": "string",
           "description": "PackageName"
         },
+        "PackageListingSuffix": {
+          "type": "string",
+          "description": "Suffix to append to the listing package name and ID"
+        },
         "Help": {
           "type": "boolean",
           "description": "Shows the help text for this build assembly"

--- a/PackageBuilder/Build.cs
+++ b/PackageBuilder/Build.cs
@@ -60,6 +60,9 @@ namespace VRC.PackageManagement.Automation
         // assumes that "template-package" repo is checked out in sibling dir to this repo, can be overridden
         [Parameter("Path to Target Package")] 
         AbsolutePath LocalTestPackagesPath => RootDirectory.Parent / "template-package"  / "Packages";
+
+        [Parameter("Suffix to append to the listing package name and ID")]
+        string PackageListingSuffix = "Listing";
         
         AbsolutePath PackageListingSourcePath => PackageListingSourceFolder / PackageListingSourceFilename;
         AbsolutePath WebPageSourcePath => PackageListingSourceFolder / "Website";
@@ -84,8 +87,12 @@ namespace VRC.PackageManagement.Automation
         {
             var result = new ListingSource()
             {
-                name = $"{manifest.displayName} Listing",
-                id = $"{manifest.name}.listing",
+                name = PackageListingSuffix != ""
+                    ? $"{manifest.displayName} {PackageListingSuffix}"
+                    : $"{manifest.displayName}",
+                id = PackageListingSuffix != ""
+                    ? $"{manifest.name}.{PackageListingSuffix.ToLower()}"
+                    : $"{manifest.name}",
                 author = new VRC.PackageManagement.Automation.Multi.Author()
                 {
                     name = manifest.author.name ?? "",

--- a/PackageBuilder/Build.cs
+++ b/PackageBuilder/Build.cs
@@ -53,9 +53,15 @@ namespace VRC.PackageManagement.Automation
             ? RootDirectory.Parent
             : RootDirectory.Parent / "template-package-listing";
 
+        private string _currentListingUrl;
         [Parameter("Path to existing index.json file, typically https://{owner}.github.io/{repo}/index.json")]
-        string CurrentListingUrl =>
-            $"https://{GitHubActions.RepositoryOwner}.github.io/{GitHubActions.Repository.Split('/')[1]}/{PackageListingPublishFilename}";
+        public string CurrentListingUrl
+        {
+            get => _currentListingUrl ?? 
+                $"https://{GitHubActions.RepositoryOwner}.github.io/{GitHubActions.Repository.Split('/')[1]}/{PackageListingPublishFilename}";
+
+            set => _currentListingUrl = value;
+        }
         
         // assumes that "template-package" repo is checked out in sibling dir to this repo, can be overridden
         [Parameter("Path to Target Package")] 

--- a/PackageBuilder/Build.cs
+++ b/PackageBuilder/Build.cs
@@ -93,10 +93,10 @@ namespace VRC.PackageManagement.Automation
         {
             var result = new ListingSource()
             {
-                name = PackageListingSuffix != ""
+                name = !string.IsNullOrWhiteSpace(PackageListingSuffix)
                     ? $"{manifest.displayName} {PackageListingSuffix}"
                     : $"{manifest.displayName}",
-                id = PackageListingSuffix != ""
+                id = !string.IsNullOrWhiteSpace(PackageListingSuffix)
                     ? $"{manifest.name}.{PackageListingSuffix.ToLower()}"
                     : $"{manifest.name}",
                 author = new VRC.PackageManagement.Automation.Multi.Author()


### PR DESCRIPTION
This allows adding a suffix to the package listing, and allows setting the listing url directly instead of it being generated from the repository name, which allows for custom domains to be used