### PR TITLE
Fix latest package resolution

### DIFF
--- a/PackageBuilder/Build.cs
+++ b/PackageBuilder/Build.cs
@@ -16,7 +16,7 @@ using Octokit;
 using VRC.PackageManagement.Core.Types.Packages;
 using ProductHeaderValue = Octokit.ProductHeaderValue;
 using ListingSource = VRC.PackageManagement.Automation.Multi.ListingSource;
-using SemVer = SemanticVersioning.Version;
+using VPMVersion = VRC.PackageManagement.Core.Types.VPMVersion.Version;
 
 namespace VRC.PackageManagement.Automation
 {
@@ -235,7 +235,7 @@ namespace VRC.PackageManagement.Automation
                 
                 Serilog.Log.Information($"Made listingInfo {JsonConvert.SerializeObject(listingInfo, JsonWriteOptions)}");
 
-                var latestPackages = packages.OrderByDescending(p => new SemVer(p.Version, true)).DistinctBy(p => p.Id).ToList();
+                var latestPackages = packages.OrderByDescending(p => new VPMVersion(p.Version, true)).DistinctBy(p => p.Id).ToList();
                 Serilog.Log.Information($"LatestPackages: {JsonConvert.SerializeObject(latestPackages, JsonWriteOptions)}");
                 var formattedPackages = latestPackages.ConvertAll(p => new {
                     Name = p.Id,

--- a/PackageBuilder/Build.cs
+++ b/PackageBuilder/Build.cs
@@ -16,6 +16,7 @@ using Octokit;
 using VRC.PackageManagement.Core.Types.Packages;
 using ProductHeaderValue = Octokit.ProductHeaderValue;
 using ListingSource = VRC.PackageManagement.Automation.Multi.ListingSource;
+using SemVer = SemanticVersioning.Version;
 
 namespace VRC.PackageManagement.Automation
 {
@@ -234,7 +235,7 @@ namespace VRC.PackageManagement.Automation
                 
                 Serilog.Log.Information($"Made listingInfo {JsonConvert.SerializeObject(listingInfo, JsonWriteOptions)}");
 
-                var latestPackages = packages.OrderByDescending(p => p.Version).DistinctBy(p => p.Id).ToList();
+                var latestPackages = packages.OrderByDescending(p => new SemVer(p.Version, true)).DistinctBy(p => p.Id).ToList();
                 Serilog.Log.Information($"LatestPackages: {JsonConvert.SerializeObject(latestPackages, JsonWriteOptions)}");
                 var formattedPackages = latestPackages.ConvertAll(p => new {
                     Name = p.Id,


### PR DESCRIPTION
This PR fixes minor version number resolution, which tweaks version `X.9.0` > `X.10.0` and make generated page displays inaccurately, which #18 has mentioned.

I know there was another PR (#19) also trying to fix this, but they uses natural string instead of semantic versioning for sorting versions, which the later one is what the package manager actually uses. I think it would be better to use the same thing as it will more accurate and clean, and with lesser extra code.