### PR TITLE
Update to use the new Scriban Render APIs in v7.0.0

### DIFF
--- a/PackageBuilder/Build.cs
+++ b/PackageBuilder/Build.cs
@@ -271,11 +271,12 @@ namespace VRC.PackageManagement.Automation
                     ).ToList(),
                 });
 
-                var model = new ScriptObject() {
+                var model = new Scriban.Runtime.ScriptObject()
+                {
                     ["listingInfo"] = listingInfo,
                     ["packages"] = formattedPackages
                 };
-                var context = new TemplateContext()
+                var context = new Scriban.TemplateContext()
                 {
                     MemberRenamer = member => member.Name
                 };

--- a/PackageBuilder/Build.cs
+++ b/PackageBuilder/Build.cs
@@ -270,16 +270,20 @@ namespace VRC.PackageManagement.Automation
                         }
                     ).ToList(),
                 });
-                
-                var rendered = Scriban.Template.Parse(indexTemplateContent).Render(
-                    new { listingInfo, packages = formattedPackages }, member => member.Name
-                );
-                
+
+                var model = new ScriptObject() {
+                    ["listingInfo"] = listingInfo,
+                    ["packages"] = formattedPackages
+                };
+                var context = new TemplateContext()
+                {
+                    MemberRenamer = member => member.Name
+                };
+                context.PushGlobal(model);
+                var rendered = Scriban.Template.ParseLiquid(indexTemplateContent).Render(context);
                 File.WriteAllText(indexWritePath, rendered);
 
-                var appJsRendered = Scriban.Template.Parse(File.ReadAllText(appReadPath)).Render(
-                    new { listingInfo, packages = formattedPackages }, member => member.Name
-                );
+                var appJsRendered = Scriban.Template.ParseLiquid(File.ReadAllText(appReadPath)).Render(context);
                 File.WriteAllText(indexAppWritePath, appJsRendered);
 
                 if (!IsServerBuild) {

--- a/PackageBuilder/PackageBuilder.csproj
+++ b/PackageBuilder/PackageBuilder.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Nuke.Common" Version="6.2.1" />
-    <PackageReference Include="Scriban" Version="5.5.0" />
+    <PackageReference Include="Scriban" Version="7.0.0" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
This commit makes the following changes:
- Uses the new Render APIs added in v7.0.0 to add support fro trimming and Native AOT compilations that can both improve performance.
- Migrates from Template.Parse -> Template.ParseLiquid as the templates I feel should be liquid based as other template engines could be more optimized stuff (such as Fluid) and allows one to use those template engines as well in their own custom code too. Also would allow for easier migration later if Scriban ever decides to stop maintaining their library and the library ends up with vulnerabilities found in it in the future. This would help future proof the templates.

Related: https://github.com/vrchat-community/template-package/pull/28